### PR TITLE
Rajashri| BAH-763 fix openmrs files not found error during installer …

### DIFF
--- a/bahmni-emr/scripts/preinstall.sh
+++ b/bahmni-emr/scripts/preinstall.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 
-#rm -rf /opt/openmrs
-#rm -rf /etc/openmrs
+rm -rf /opt/openmrs
+rm -rf /etc/openmrs
 
 rm -rf /etc/init.d/openmrs
 rm -rf /var/run/openmrs

--- a/bahmni-installer/scripts/preinstall.sh
+++ b/bahmni-installer/scripts/preinstall.sh
@@ -9,7 +9,3 @@ rm -rf /usr/bin/bahmni
 rm -rf /etc/bahmni-installer/deployment-artifacts/rpm_versions.yml
 rm -rf /etc/bahmni-installer/deployment-artifacts/local
 rm -rf /var/log/bahmni-installer
-
-#Moved from bahmni-emr pre-install
-rm -rf /opt/openmrs
-rm -rf /etc/openmrs 


### PR DESCRIPTION
…upgrade

details : install bahmni installer 1.x version and emr y version.on the top of this install bahmni installer 1.x.1 version and emr version is still same(i.e) during emr installation error was thrown /opt/openmrs files not found