### PR TITLE
BAH-848 | postinstall script should call link_dir before create_configuration_dirs

### DIFF
--- a/bahmni-emr/resources/openmrs-runtime.properties
+++ b/bahmni-emr/resources/openmrs-runtime.properties
@@ -1,0 +1,6 @@
+auto_update_database=true
+connection.username=openmrs-user
+connection.password=P@ssw0rd
+connection.url=jdbc:mysql://localhost:3306/openmrs?autoReconnect=true&sessionVariables=storage_engine=InnoDB&useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull
+application_data_directory=/opt/openmrs/
+module.allow_web_admin=false

--- a/bahmni-emr/scripts/postinstall.sh
+++ b/bahmni-emr/scripts/postinstall.sh
@@ -34,14 +34,14 @@ sudo chown -R bahmni:bahmni /var/run/openmrs
 sudo chown -R bahmni:bahmni /etc/init.d/openmrs
 sudo chown -R bahmni:bahmni /etc/openmrs
 
-link_dirs(){
+link_dirs() {
     rm -rf /home/$OPENMRS_SERVER_USER/.OpenMRS/modules
     ln -s $MODULE_REPO /home/$OPENMRS_SERVER_USER/.OpenMRS/modules
     chown -R bahmni:bahmni /opt/openmrs/modules
 }
 
 
-run_migrations(){
+run_migrations() {
     echo "Running openmrs liquibase-core-data.xml and liquibase-update-to-latest.xml"
     /opt/openmrs/etc/run-liquibase.sh liquibase-core-data.xml
     /opt/openmrs/etc/run-liquibase.sh liquibase-update-to-latest.xml
@@ -53,7 +53,7 @@ run_migrations(){
 #    cp -f /opt/openmrs/modules/mail-appender-*.jar /opt/openmrs/openmrs/WEB-INF/lib/
 #}
 
-create_configuration_dirs(){
+create_configuration_dirs() {
     ln -s /opt/openmrs/bahmnicore.properties /home/$OPENMRS_SERVER_USER/.OpenMRS/bahmnicore.properties
     mkdir -p $PATIENT_IMAGES_DIR
     mkdir -p $DOCUMENT_IMAGES_DIR
@@ -77,9 +77,10 @@ setupConfFiles() {
     	cp -f /opt/openmrs/etc/emr_ssl.conf /etc/httpd/conf.d/emr_ssl.conf
 }
 
+link_dirs
 create_configuration_dirs
 
-link_dirs
+
 if [ "${IS_PASSIVE:-0}" -ne "1" ]; then
     run_migrations
 fi

--- a/bahmni-emr/scripts/rpm/openmrs
+++ b/bahmni-emr/scripts/rpm/openmrs
@@ -47,7 +47,7 @@ link_modules() {
         chown bahmni:bahmni /home/$OPENMRS_SERVER_USER/.OpenMRS
         ln -s /opt/openmrs/etc/openmrs-runtime.properties /home/$OPENMRS_SERVER_USER/.OpenMRS/openmrs-runtime.properties
     fi
-    if [[ ! -e/home/$OPENMRS_SERVER_USER/.OpenMRS/modules ]]; then
+    if [[ ! -e /home/$OPENMRS_SERVER_USER/.OpenMRS/modules ]]; then
         ln -s $MODULE_REPO /home/$OPENMRS_SERVER_USER/.OpenMRS/modules
     fi
 }


### PR DESCRIPTION
link_dir should be called first, as its cleaning up the /home/bahmni/.OpenMRS/ directory