### PR TITLE
BAH-939 | updating rpm pre and post install scripts not to create /va/run/service directory

### DIFF
--- a/bahmni-emr/scripts/postinstall.sh
+++ b/bahmni-emr/scripts/postinstall.sh
@@ -7,8 +7,6 @@ fi
 #create links
 sudo ln -s /opt/openmrs/etc /etc/openmrs
 sudo ln -s /opt/openmrs/bin/openmrs /etc/init.d/openmrs
-sudo ln -s /opt/openmrs/run /var/run/openmrs
-sudo ln -s /opt/openmrs/openmrs /var/run/openmrs/openmrs
 sudo ln -s /opt/openmrs/log /var/log/openmrs
 
 . /etc/openmrs/openmrs.conf
@@ -30,7 +28,6 @@ sudo cp -f /opt/openmrs/etc/web.xml /opt/openmrs/openmrs/WEB-INF/
 # permissions
 sudo chown -R bahmni:bahmni /opt/openmrs
 sudo chown -R bahmni:bahmni /var/log/openmrs
-sudo chown -R bahmni:bahmni /var/run/openmrs
 sudo chown -R bahmni:bahmni /etc/init.d/openmrs
 sudo chown -R bahmni:bahmni /etc/openmrs
 

--- a/bahmni-emr/scripts/preinstall.sh
+++ b/bahmni-emr/scripts/preinstall.sh
@@ -5,7 +5,6 @@ rm -rf /opt/openmrs
 rm -rf /etc/openmrs
 
 rm -rf /etc/init.d/openmrs
-rm -rf /var/run/openmrs
 rm -rf /var/log/openmrs
 
 rm -f /home/bahmni/.OpenMRS/bahmnicore.properties

--- a/bahmni-erp-connect/scripts/postinstall.sh
+++ b/bahmni-erp-connect/scripts/postinstall.sh
@@ -21,8 +21,6 @@ link_directories(){
     #create links
     ln -s /opt/bahmni-erp-connect/etc /etc/bahmni-erp-connect
     ln -s /opt/bahmni-erp-connect/bin/bahmni-erp-connect /etc/init.d/bahmni-erp-connect
-    ln -s /opt/bahmni-erp-connect/run /var/run/bahmni-erp-connect
-    ln -s /opt/bahmni-erp-connect/bahmni-erp-connect /var/run/bahmni-erp-connect/bahmni-erp-connect
     ln -s /opt/bahmni-erp-connect/log /var/log/bahmni-erp-connect
 }
 
@@ -30,7 +28,6 @@ manage_permissions(){
     # permissions
     chown -R bahmni:bahmni /opt/bahmni-erp-connect
     chown -R bahmni:bahmni /var/log/bahmni-erp-connect
-    chown -R bahmni:bahmni /var/run/bahmni-erp-connect
     chown -R bahmni:bahmni /etc/init.d/bahmni-erp-connect
     chown -R bahmni:bahmni /etc/bahmni-erp-connect
 }

--- a/bahmni-erp-connect/scripts/preinstall.sh
+++ b/bahmni-erp-connect/scripts/preinstall.sh
@@ -3,5 +3,4 @@
 rm -rf /opt/bahmni-erp-connect
 rm -rf /etc/bahmni-erp-connect
 rm -rf /etc/init.d/bahmni-erp-connect
-rm -rf /var/run/bahmni-erp-connect
 rm -rf /var/log/bahmni-erp-connect

--- a/bahmni-event-log-service/scripts/postinstall.sh
+++ b/bahmni-event-log-service/scripts/postinstall.sh
@@ -21,8 +21,6 @@ link_directories(){
     #create links
     ln -s /opt/bahmni-event-log-service/etc /etc/bahmni-event-log-service
     ln -s /opt/bahmni-event-log-service/bin/bahmni-event-log-service /etc/init.d/bahmni-event-log-service
-    ln -s /opt/bahmni-event-log-service/run /var/run/bahmni-event-log-service
-    ln -s /opt/bahmni-event-log-service/bahmni-event-log-service /var/run/bahmni-event-log-service/bahmni-event-log-service
     ln -s /opt/bahmni-event-log-service/log /var/log/bahmni-event-log-service
 }
 
@@ -30,7 +28,6 @@ manage_permissions(){
     # permissions
     chown -R bahmni:bahmni /opt/bahmni-event-log-service
     chown -R bahmni:bahmni /var/log/bahmni-event-log-service
-    chown -R bahmni:bahmni /var/run/bahmni-event-log-service
     chown -R bahmni:bahmni /etc/init.d/bahmni-event-log-service
     chown -R bahmni:bahmni /etc/bahmni-event-log-service
 }

--- a/bahmni-event-log-service/scripts/preinstall.sh
+++ b/bahmni-event-log-service/scripts/preinstall.sh
@@ -3,5 +3,4 @@
 rm -rf /opt/bahmni-event-log-service
 rm -rf /etc/bahmni-event-log-service
 rm -rf /etc/init.d/bahmni-event-log-service
-rm -rf /var/run/bahmni-event-log-service
 rm -f /etc/httpd/conf.d/bahmni_eventlog_ssl.conf

--- a/bahmni-lab/scripts/postinstall.sh
+++ b/bahmni-lab/scripts/postinstall.sh
@@ -23,8 +23,6 @@ mkdir -p /home/bahmni/uploaded-files/elis
 #create links
 ln -s /opt/bahmni-lab/etc /etc/bahmni-lab
 ln -s /opt/bahmni-lab/bin/bahmni-lab /etc/init.d/bahmni-lab
-ln -s /opt/bahmni-lab/run /var/run/bahmni-lab
-ln -s /opt/bahmni-lab/bahmni-lab /var/run/bahmni-lab/bahmni-lab
 ln -s /opt/bahmni-lab/log /var/log/bahmni-lab
 ln -s /opt/bahmni-lab/uploaded-files/elis /home/bahmni/uploaded-files/elis
 
@@ -63,7 +61,6 @@ chkconfig --add bahmni-lab
 # permissions
 chown -R bahmni:bahmni /opt/bahmni-lab
 chown -R bahmni:bahmni /var/log/bahmni-lab
-chown -R bahmni:bahmni /var/run/bahmni-lab
 chown -R bahmni:bahmni /etc/init.d/bahmni-lab
 chown -R bahmni:bahmni /etc/bahmni-lab
 

--- a/bahmni-lab/scripts/preinstall.sh
+++ b/bahmni-lab/scripts/preinstall.sh
@@ -4,7 +4,6 @@ rm -rf /opt/bahmni-lab
 
 rm -rf /etc/bahmni-lab
 rm -rf /etc/init.d/bahmni-lab
-rm -rf /var/run/bahmni-lab
 rm -rf /var/log/bahmni-lab
 rm -rf /home/bahmni/uploaded-files/elis
 rm -f /etc/httpd/conf.d/bahmnilab_ssl.conf

--- a/bahmni-pacs/scripts/pacs-integration/postinstall.sh
+++ b/bahmni-pacs/scripts/pacs-integration/postinstall.sh
@@ -15,11 +15,8 @@ groupadd bahmni
 [ $? -eq 1 ]
 useradd -g bahmni bahmni
 
-mkdir /var/run/pacs-integration
 mkdir /var/log/pacs-integration
 #create links
-ln -s /opt/pacs-integration/run /var/run/pacs-integration
-ln -s /opt/pacs-integration/pacs-integration /var/run/pacs-integration/pacs-integration
 ln -s /opt/pacs-integration/bin/pacs-integration /etc/init.d/pacs-integration
 ln -s /opt/pacs-integration/etc  /etc/pacs-integration
 #create a database if it doesn't exist and if it is not passive machine.
@@ -32,4 +29,4 @@ chkconfig --add pacs-integration
 chown -R bahmni:bahmni /opt/pacs-integration
 chown -R bahmni:bahmni /var/log/pacs-integration
 chown -R bahmni:bahmni /etc/init.d/pacs-integration
-chown -R bahmni:bahmni /var/run/pacs-integration
+

--- a/bahmni-pacs/scripts/pacs-integration/preinstall.sh
+++ b/bahmni-pacs/scripts/pacs-integration/preinstall.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-rm -rf /var/run/pacs-integration
 rm -rf /etc/pacs-integration
 rm -rf /etc/init.d/pacs-integration
 rm -rf /opt/pacs-integration

--- a/bahmni-reports/scripts/postinstall.sh
+++ b/bahmni-reports/scripts/postinstall.sh
@@ -23,8 +23,6 @@ link_directories(){
     #create links
     ln -s /opt/bahmni-reports/etc /etc/bahmni-reports
     ln -s /opt/bahmni-reports/bin/bahmni-reports /etc/init.d/bahmni-reports
-    ln -s /opt/bahmni-reports/run /var/run/bahmni-reports
-    ln -s /opt/bahmni-reports/bahmni-reports /var/run/bahmni-reports/bahmni-reports
     ln -s /opt/bahmni-reports/log /var/log/bahmni-reports
 }
 
@@ -32,7 +30,6 @@ manage_permissions(){
     # permissions
     chown -R bahmni:bahmni /opt/bahmni-reports
     chown -R bahmni:bahmni /var/log/bahmni-reports
-    chown -R bahmni:bahmni /var/run/bahmni-reports
     chown -R bahmni:bahmni /etc/init.d/bahmni-reports
     chown -R bahmni:bahmni /etc/bahmni-reports
 }

--- a/bahmni-reports/scripts/preinstall.sh
+++ b/bahmni-reports/scripts/preinstall.sh
@@ -3,6 +3,5 @@
 rm -rf /opt/bahmni-reports
 rm -rf /etc/bahmni-reports
 rm -rf /etc/init.d/bahmni-reports
-rm -rf /var/run/bahmni-reports
 rm -rf /var/log/bahmni-reports
 rm -f /etc/httpd/conf.d/bahmni_reports_ssl.conf


### PR DESCRIPTION
updating rpm pre and post install scripts not to create /var/run/[service-name]. The /var/run/[service-name] directory is henceforth created by systemd unit files.