### PR TITLE
Praveena | Buvana | BAH-1054 - Install Soupsieve before running pytho…

### DIFF
--- a/bahmni-erp/scripts/postinstall.sh
+++ b/bahmni-erp/scripts/postinstall.sh
@@ -28,6 +28,7 @@ install_openerp(){
     cd $BAHMNI_ERP
     unzip odoo_10.0.20190619.zip
     mv odoo-10.0.post20190619/* .
+    sudo pip install soupsieve
     sudo python setup.py -q install
     # cp debian/odoo.conf $BAHMNI_ERP/etc
     mkdir bahmni-addons


### PR DESCRIPTION
Pip installing soupsieve will enable install of 1.9.6 that is python2 compatible. soupsieve 2.0.1 expects python3. easy_install of soupsieve causes download of 2.0.1 instead of 1.9.6.