### PR TITLE
BAH-1229|gurpreet| Updating the GoCD CI server URL

### DIFF
--- a/bahmni-erp/test/bahmni_openerp_revision.sh
+++ b/bahmni-erp/test/bahmni_openerp_revision.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 revision='{
-    "go" : "https://ci.mybahmni.org/go/pipelines/value_stream_map/_jobname_/_pipelineCount_",
+    "go" : "https://ci-server.mybahmni.org/go/pipelines/value_stream_map/_jobname_/_pipelineCount_",
     "github": {
         "openerp_modules" : "https://github.com/Bahmni/openerp-modules/commit/_modulesSha_",
         "functional_tests" : "https://github.com/Bahmni/openerp-functional-tests/commit/_functionalTestsSha_",

--- a/bahmni-lab/test/bahmni_openelis_revision.sh
+++ b/bahmni-lab/test/bahmni_openelis_revision.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 revision='{
-    "go" : "https://ci.mybahmni.org/go/pipelines/value_stream_map/_jobname_/_pipelineCount_",
+    "go" : "https://ci-server.mybahmni.org/go/pipelines/value_stream_map/_jobname_/_pipelineCount_",
     "github": {
         "openelis" : "https://github.com/Bahmni/OpenElis/commit/_sha_"
     }

--- a/bahmni-web/test/bahmni_openmrs_revision.sh
+++ b/bahmni-web/test/bahmni_openmrs_revision.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 revision='{
-    "go" : "https://ci.mybahmni.org/go/pipelines/value_stream_map/_jobname_/_pipelineCount_",
+    "go" : "https://ci-server.mybahmni.org/go/pipelines/value_stream_map/_jobname_/_pipelineCount_",
     "github": {
         "bahmni_core" : "https://github.com/Bahmni/bahmni-core/commit/_bahmniCoreSha_",
         "openmrs_distro_bahmni" : "https://github.com/Bahmni/openmrs-distro-bahmni/commit/_openmrsSha_",


### PR DESCRIPTION
Minor fix to GoCD URL on Bahmni Home Landing page. Changed it from `ci.mybahmni.org` to the current one: `ci-server.mybahmni.org`. 

JIRA URL: https://bahmni.atlassian.net/browse/BAH-1229