### PR TITLE
BDI-17 | Use GITHUB_RUN_NUMBER in docker build scripts

### DIFF
--- a/bahmni-docker/README.md
+++ b/bahmni-docker/README.md
@@ -123,8 +123,8 @@ The docker build scripts has been written in a way to be used in Dev Environemts
 1. Setting Up Environment Variables for build:
     * OPENELIS_IMAGE_VERSION
         * Example: `export OPENELIS_IMAGE_VERSION=0.93`
-    * GO_PIPELINE_COUNTER - Used by CI. For Dev can be set to dev
-        * Example: `export GO_PIPELINE_COUNTER=dev`
+    * GITHUB_RUN_NUMBER - Used by CI. For Dev can be set to dev
+        * Example: `export GITHUB_RUN_NUMBER=dev`
 
     These values are concatenated to form the image tag. With the example values the image tag becomes `openelis:0.93-dev`
 2. Building images:

--- a/bahmni-docker/README.md
+++ b/bahmni-docker/README.md
@@ -121,8 +121,8 @@ You can also build the docker images locally and test it with the same docker-co
 The docker files and scripts for OpenElis can be found under `bahmni-package/bahmni-lab/docker`.
 The docker build scripts has been written in a way to be used in Dev Environemts and also in CI Environment.
 1. Setting Up Environment Variables for build:
-    * OPENELIS_IMAGE_VERSION
-        * Example: `export OPENELIS_IMAGE_VERSION=0.93`
+    * BAHMNI_VERSION
+        * Example: `export BAHMNI_VERSION=0.93`
     * GITHUB_RUN_NUMBER - Used by CI. For Dev can be set to dev
         * Example: `export GITHUB_RUN_NUMBER=dev`
 

--- a/bahmni-docker/build_scripts/bahmni-erp/docker_build.sh
+++ b/bahmni-docker/build_scripts/bahmni-erp/docker_build.sh
@@ -9,7 +9,7 @@ cd bahmni-package/bahmni-erp
 # Unzipping Odoo Modules copied by CI
 unzip -q -u -d build/ resources/odoo-modules.zip
 #Building Docker images
-ODOO_IMAGE_TAG=${BAHMNI_VERSION}-${GO_PIPELINE_COUNTER}
+ODOO_IMAGE_TAG=${BAHMNI_VERSION}-${GITHUB_RUN_NUMBER}
 docker build -t bahmni/odoo-10-db:fresh-${ODOO_IMAGE_TAG} -f docker/db.Dockerfile  . --no-cache
 docker build -t bahmni/odoo-10-db:demo-${ODOO_IMAGE_TAG} -f docker/demodb.Dockerfile  . --no-cache
 docker build -t bahmni/odoo-10:${ODOO_IMAGE_TAG} -f docker/Dockerfile  . --no-cache

--- a/bahmni-docker/build_scripts/bahmni-erp/docker_publish.sh
+++ b/bahmni-docker/build_scripts/bahmni-erp/docker_publish.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-ODOO_IMAGE_TAG=${BAHMNI_VERSION}-${GO_PIPELINE_COUNTER}
+ODOO_IMAGE_TAG=${BAHMNI_VERSION}-${GITHUB_RUN_NUMBER}
 echo ${DOCKER_HUB_TOKEN} | docker login -u ${DOCKER_HUB_USERNAME} --password-stdin
 docker push bahmni/odoo-10-db:fresh-${ODOO_IMAGE_TAG}
 docker push bahmni/odoo-10-db:demo-${ODOO_IMAGE_TAG}

--- a/bahmni-docker/build_scripts/bahmni-lab/docker_build.sh
+++ b/bahmni-docker/build_scripts/bahmni-lab/docker_build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -xe
 #Building bahmni core which has embedded Tomcat Server
-cd bahmni-package && ./gradlew -PbahmniRelease=${rpm_version} :core:clean :core:build
+cd bahmni-package && ./gradlew -PbahmniRelease=${BAHMNI_VERSION} :core:clean :core:build
 cp core/build/libs/core-1.0-SNAPSHOT.jar bahmni-lab/docker/bahmni-core.jar
 cd ..
 #Fetching Database Backup Data
@@ -15,7 +15,7 @@ mkdir -p build/migrations
 fi
 unzip -u -d build/migrations resources/OpenElis.zip
 #Building Docker images
-OPENELIS_IMAGE_TAG=${OPENELIS_IMAGE_VERSION}-${GITHUB_RUN_NUMBER}
+OPENELIS_IMAGE_TAG=${BAHMNI_VERSION}-${GITHUB_RUN_NUMBER}
 docker build -t bahmni/openelis-db:fresh-${OPENELIS_IMAGE_TAG} -f docker/db.Dockerfile . --no-cache
 docker build -t bahmni/openelis-db:demo-${OPENELIS_IMAGE_TAG} -f docker/demodb.Dockerfile . --no-cache
 docker build -t bahmni/openelis:${OPENELIS_IMAGE_TAG} -f docker/Dockerfile . --no-cache

--- a/bahmni-docker/build_scripts/bahmni-lab/docker_build.sh
+++ b/bahmni-docker/build_scripts/bahmni-lab/docker_build.sh
@@ -15,7 +15,7 @@ mkdir -p build/migrations
 fi
 unzip -u -d build/migrations resources/OpenElis.zip
 #Building Docker images
-OPENELIS_IMAGE_TAG=${OPENELIS_IMAGE_VERSION}-${GO_PIPELINE_COUNTER}
+OPENELIS_IMAGE_TAG=${OPENELIS_IMAGE_VERSION}-${GITHUB_RUN_NUMBER}
 docker build -t bahmni/openelis-db:fresh-${OPENELIS_IMAGE_TAG} -f docker/db.Dockerfile . --no-cache
 docker build -t bahmni/openelis-db:demo-${OPENELIS_IMAGE_TAG} -f docker/demodb.Dockerfile . --no-cache
 docker build -t bahmni/openelis:${OPENELIS_IMAGE_TAG} -f docker/Dockerfile . --no-cache

--- a/bahmni-docker/build_scripts/bahmni-lab/docker_publish.sh
+++ b/bahmni-docker/build_scripts/bahmni-lab/docker_publish.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-OPENELIS_IMAGE_TAG=${OPENELIS_IMAGE_VERSION}-${GO_PIPELINE_COUNTER}
+OPENELIS_IMAGE_TAG=${OPENELIS_IMAGE_VERSION}-${GITHUB_RUN_NUMBER}
 echo ${DOCKER_HUB_TOKEN} | docker login -u ${DOCKER_HUB_USERNAME} --password-stdin
 docker push bahmni/openelis-db:fresh-${OPENELIS_IMAGE_TAG}
 docker push bahmni/openelis-db:demo-${OPENELIS_IMAGE_TAG}

--- a/bahmni-docker/build_scripts/bahmni-lab/docker_publish.sh
+++ b/bahmni-docker/build_scripts/bahmni-lab/docker_publish.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-OPENELIS_IMAGE_TAG=${OPENELIS_IMAGE_VERSION}-${GITHUB_RUN_NUMBER}
+OPENELIS_IMAGE_TAG=${BAHMNI_VERSION}-${GITHUB_RUN_NUMBER}
 echo ${DOCKER_HUB_TOKEN} | docker login -u ${DOCKER_HUB_USERNAME} --password-stdin
 docker push bahmni/openelis-db:fresh-${OPENELIS_IMAGE_TAG}
 docker push bahmni/openelis-db:demo-${OPENELIS_IMAGE_TAG}


### PR DESCRIPTION
As we are using Github Actions for Docker image build and publish, GO_PIPELINE_COUNTER variable is changed to GITHUB_RUN_NUMBER