### PR TITLE
BDI-19 | Use SHA for Odoo base image

### DIFF
--- a/bahmni-erp/docker/Dockerfile
+++ b/bahmni-erp/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM odoo:10.0
+FROM odoo@sha256:7bbade53c6b07b5c31046ab5d85d9f7c9115d731ec585c2146b8005bb2944d39
 
 COPY docker/odoo.conf /etc/odoo/odoo.conf
 COPY build/odoo-modules /opt/bahmni-erp/bahmni-addons


### PR DESCRIPTION
Replacing docker image tag with SHA value to ensure that the Odoo version is locked to a particular version.