### PR TITLE
BDI-29 | Fix | Directory creation issue in GH Actions

### DIFF
--- a/bahmni-docker/build_scripts/bahmni-lab/docker_build.sh
+++ b/bahmni-docker/build_scripts/bahmni-lab/docker_build.sh
@@ -15,15 +15,16 @@ gunzip -f -k bahmni-scripts/demo/db-backups/v0.92/openelis_backup.sql.gz
 cp bahmni-scripts/demo/db-backups/v0.92/openelis_backup.sql bahmni-package/bahmni-lab/resources/openelis_demo_dump.sql
 cd bahmni-package/bahmni-lab
 
-# Unzipping Default Config
-unzip -q -u -d build/default_config resources/default_config.zip
-
 #Extracting Migrations Zip
 if [ ! -d build/migrations ]
 then
 mkdir -p build/migrations
 fi
 unzip -u -d build/migrations resources/OpenElis.zip
+
+# Unzipping Default Config
+unzip -q -u -d build/default_config resources/default_config.zip
+
 #Building Docker images
 OPENELIS_IMAGE_TAG=${BAHMNI_VERSION}-${GITHUB_RUN_NUMBER}
 docker build -t bahmni/openelis-db:fresh-${OPENELIS_IMAGE_TAG} -f docker/db.Dockerfile . --no-cache


### PR DESCRIPTION
#69 had an issue with OpenELIS workflow as the extraction command has been included before creation of build directory. This fixes the issue.