### PR TITLE
BAH-1304 | Add | Steps to remove induilt FHIR OMOD

### DIFF
--- a/bahmni-emr/docker/Dockerfile
+++ b/bahmni-emr/docker/Dockerfile
@@ -17,4 +17,8 @@ RUN apt-get update && apt-get install gettext-base
 COPY docker/scripts/bahmni_startup.sh /usr/local/tomcat/
 RUN chmod +x /usr/local/tomcat/bahmni_startup.sh
 
+# Removing FHIR OMOD that comes bundled with OMRS base image
+RUN unzip -o /usr/local/tomcat/webapps/openmrs.war -d /usr/local/tomcat/webapps/openmrs/
+RUN rm /usr/local/tomcat/webapps/openmrs/WEB-INF/bundledModules/fhir-*.omod
+
 CMD ["./bahmni_startup.sh"]


### PR DESCRIPTION
This PR adds build commands in Dockerfile to remove FHIR1 OMOD which comes bundled with OpenMRS base image. 