### PR TITLE
FIX: Caching on API endpoints 

### DIFF
--- a/bahmni-proxy/resources/bahmni-proxy.conf
+++ b/bahmni-proxy/resources/bahmni-proxy.conf
@@ -85,7 +85,6 @@ Listen 443
 				CacheEnable disk /bahmni
                 CacheEnable disk /openmrs/ws/rest/v1/concept
 
-        Header set Cache-Control "max-age=86400"
 	    CacheDirLevels 5
 		CacheDirLength 3
 		CacheDefaultExpire 3600
@@ -161,6 +160,13 @@ Listen 443
         Order deny,allow
         Allow from all
     </Directory>
+</VirtualHost>
+
+<VirtualHost *:80>
+  RewriteEngine On
+  RewriteCond %{HTTPS} off
+
+  RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI}
 </VirtualHost>
 
 ServerTokens Prod


### PR DESCRIPTION
- This PR fixes the cache issue identified on proxy container of docker which caches every request that flows through proxy because the `Header set Cache Control ` happens at root level. 
- Also a redirect to https is added so that every request becomes https