### PR TITLE
BAH-2436 | Use corretto as base image for atomfeed-console

### DIFF
--- a/atomfeed-console/Dockerfile
+++ b/atomfeed-console/Dockerfile
@@ -1,8 +1,8 @@
-FROM openjdk:8-alpine
+FROM amazoncorretto:8
 COPY resources/application.yml.template .
 COPY resources/start.sh .
 COPY resources/*.jar .
-RUN apk add gettext
+RUN yum install -y gettext
 EXPOSE 9080
 RUN chmod +x start.sh 
 ENTRYPOINT ["./start.sh"]


### PR DESCRIPTION
Using amazoncorreto as baseimage since openjdk builds has beeen deprecated. More info [here](https://talk.openmrs.org/t/using-amazoncorretto-as-base-image-for-bahmni-docker-images/37668).

Co-authored-by: Divij Goyal [divij.g@beehyv.com](mailto:divij.g@beehyv.com)