### PR TITLE
BAH-3969 | Add. Bahmni Embedded Tomcat v10

### DIFF
--- a/.github/workflows/tomcat_build_upload.yml
+++ b/.github/workflows/tomcat_build_upload.yml
@@ -5,12 +5,13 @@ on:
       - master
     paths:
       - "bahmni-embedded-tomcat/**"
+      - "bahmni-embedded-tomcat-10/**"
       - "gradle.properties"
       - ".github/workflows/tomcat_build_upload.yml"
   workflow_dispatch:
 
 jobs:
-  Trivy:
+  trivy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -21,14 +22,15 @@ jobs:
   build-upload-artifact:
     name: Build and upload embedded Tomcat Server artifact
     runs-on: ubuntu-latest
-    needs: Trivy
+    needs: trivy
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.8
-      - name: Generate Artifact
+          distribution: 'adopt'
+          java-version: '1.8'
+      - name: Generate Artifact for bahmni-embedded-tomcat
         run: ./gradlew :bahmni-embedded-tomcat:clean :bahmni-embedded-tomcat:build
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -36,5 +38,26 @@ jobs:
           aws-access-key-id: ${{ secrets.S3_MVN_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.S3_MVN_SECRET_KEY }}
           aws-region: ap-southeast-1
-      - name: Upload Artifact
+      - name: Upload Artifact for bahmni-embedded-tomcat
         run: aws s3 cp bahmni-embedded-tomcat/build/libs/bahmni-embedded-tomcat-*.jar s3://repo.mybahmni.org/packages/build/
+
+  build-upload-artifact-10:
+    name: Build and upload embedded Tomcat 10 Server artifact
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '17'
+      - name: Generate Artifact for bahmni-embedded-tomcat-10
+        run: mvn clean package -f bahmni-embedded-tomcat-10/pom.xml
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.S3_MVN_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.S3_MVN_SECRET_KEY }}
+          aws-region: ap-southeast-1
+      - name: Upload Artifact for bahmni-embedded-tomcat-10
+        run: aws s3 cp bahmni-embedded-tomcat-10/target/bahmni-embedded-tomcat-10-*.jar s3://repo.mybahmni.org/packages/build/

--- a/.github/workflows/tomcat_build_upload.yml
+++ b/.github/workflows/tomcat_build_upload.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up JDK 1.8
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'corretto'
           java-version: '1.8'
       - name: Generate Artifact for bahmni-embedded-tomcat
         run: ./gradlew :bahmni-embedded-tomcat:clean :bahmni-embedded-tomcat:build
@@ -49,7 +49,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'corretto'
           java-version: '17'
       - name: Generate Artifact for bahmni-embedded-tomcat-10
         run: mvn clean package -f bahmni-embedded-tomcat-10/pom.xml

--- a/bahmni-embedded-tomcat-10/.gitignore
+++ b/bahmni-embedded-tomcat-10/.gitignore
@@ -1,0 +1,38 @@
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### IntelliJ IDEA ###
+.idea/modules.xml
+.idea/jarRepositories.xml
+.idea/compiler.xml
+.idea/libraries/
+*.iws
+*.iml
+*.ipr
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store

--- a/bahmni-embedded-tomcat-10/pom.xml
+++ b/bahmni-embedded-tomcat-10/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.bahmni.deployment.launch</groupId>
+    <artifactId>bahmni-embedded-tomcat-10</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>Bahmni Embedded Tomcat 10</name>
+    <url>https://github.com/Bahmni/bahmni-package.git</url>
+    <description>Embedded Tomcat v10 For Bahmni Services</description>
+    <licenses>
+        <license>
+            <name>GNU AFFERO GENERAL PUBLIC LICENSE</name>
+            <url>https://www.gnu.org/licenses/agpl-3.0.txt</url>
+        </license>
+    </licenses>
+    <developers>
+        <developer>
+            <name>Bahmni</name>
+            <email>info@bahmni.org</email>
+            <organization>Bahmni</organization>
+            <organizationUrl>https://github.com/Bahmni</organizationUrl>
+        </developer>
+    </developers>
+    <scm>
+        <connection>scm:git:git@github.com:Bahmni/bahmni-package.git</connection>
+        <developerConnection>scm:git:git@github.com:Bahmni/bahmni-package.git</developerConnection>
+        <url>https://github.com/Bahmni/bahmni-package/tree/master/bahmni-embedded-tomcat-10/</url>
+    </scm>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <tomcatVersion>10.1.24</tomcatVersion>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+            <version>${tomcatVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-juli</artifactId>
+            <version>${tomcatVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-jasper</artifactId>
+            <version>${tomcatVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-jasper</artifactId>
+            <version>${tomcatVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-jasper-el</artifactId>
+            <version>${tomcatVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-jsp-api</artifactId>
+            <version>${tomcatVersion}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.0.0</version>
+                <configuration>
+                    <mainClass>org.bahmni.deployment.launch.Main</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/bahmni-embedded-tomcat-10/src/main/java/org/bahmni/deployment/launch/Main.java
+++ b/bahmni-embedded-tomcat-10/src/main/java/org/bahmni/deployment/launch/Main.java
@@ -1,0 +1,25 @@
+package org.bahmni.deployment.launch;
+
+import org.apache.catalina.LifecycleException;
+import org.apache.catalina.startup.Tomcat;
+import org.apache.catalina.Context;
+
+import java.io.File;
+import java.net.MalformedURLException;
+
+import static java.lang.System.getenv;
+
+public class Main {
+    public static void main(String[] args) throws LifecycleException {
+        Tomcat tomcat = new Tomcat();
+        tomcat.setPort(Integer.parseInt(getenv("SERVER_PORT")));
+        tomcat.setBaseDir(getenv("BASE_DIR"));
+
+        Context context = tomcat.addWebapp(getenv("CONTEXT_PATH"), new File(getenv("WAR_DIRECTORY")).getAbsolutePath());
+        context.setSessionTimeout(120);
+        context.setUseHttpOnly(false);
+
+        tomcat.start();
+        tomcat.getServer().await();
+    }
+}

--- a/bahmni-embedded-tomcat-10/src/main/java/org/bahmni/deployment/launch/Main.java
+++ b/bahmni-embedded-tomcat-10/src/main/java/org/bahmni/deployment/launch/Main.java
@@ -1,16 +1,18 @@
 package org.bahmni.deployment.launch;
 
+import jakarta.servlet.ServletException;
+import org.apache.catalina.Context;
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.startup.Tomcat;
-import org.apache.catalina.Context;
 
 import java.io.File;
-import java.net.MalformedURLException;
+import java.io.FileNotFoundException;
+import java.io.IOException;
 
 import static java.lang.System.getenv;
 
 public class Main {
-    public static void main(String[] args) throws LifecycleException {
+    public static void main(String[] args) throws NumberFormatException, NullPointerException, IllegalArgumentException, ServletException, LifecycleException, IllegalStateException, FileNotFoundException, IOException{
         Tomcat tomcat = new Tomcat();
         tomcat.setPort(Integer.parseInt(getenv("SERVER_PORT")));
         tomcat.setBaseDir(getenv("BASE_DIR"));


### PR DESCRIPTION
JIRA -> [BAH-3969](https://bahmni.atlassian.net/browse/BAH-3969)

In this PR, the following changes are introduced: 
1. **Bahmni Embedded Tomcat v10**: Migrating from Java 11 to Java 17 necessitates upgrading the embedded Tomcat version to at least Tomcat 10, as Tomcat 8 is not compatible with Java 17. This task involves creating, testing, and publishing a Tomcat 10 jar that can be embedded within Bahmni applications. The new jar will ensure compatibility with the updated Java runtime and provide the necessary features and security updates.
2. **Updated Workflow**: This workflow should build and upload both versions of the bahmni-embedded-tomcat to AWS S3 correctly.